### PR TITLE
feat(index.js): Change routes to match with the standard

### DIFF
--- a/index.js
+++ b/index.js
@@ -246,7 +246,8 @@ async function start() {
         await writeIdentity(identifier)
         const response = {
           did,
-          mnemonic: identifier.mnemonic
+          mnemonic: identifier.mnemonic,
+          ddo: identifier.ddo
         }
         info('%s: New Identity created successfully: %s', pkg.name, did)
 


### PR DESCRIPTION
Fixes #
* This PR addresses the changes discussed regarding keeping standard routes across all network nodes and a few minor changes

## Proposed Changes

- Change the `create` & `resolve` api routes to match the standard with that of other network nodes
- Send the DDO as part of the create api response
- Allow password to be passed through `opts` when booting up the node programmatically